### PR TITLE
Remove dependency on botocore.vendored

### DIFF
--- a/python/awis.py
+++ b/python/awis.py
@@ -19,7 +19,7 @@ import sys, os, base64, hashlib, hmac
 import logging, getopt
 import boto3
 import getpass
-from botocore.vendored import requests
+import requests
 from datetime import datetime
 import time
 from configparser import ConfigParser # pip install configparser

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 boto3
 configparser
 future
+requests


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* removed dependency on `botocore.vendored` in `awis.py` because the sample code does not work. This follows the directions in [botocore documentation](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html#upgrading-to-1-11-0) that instructs to not use `botocore.vendored.requests`. Replaced with the standard `requests` library in `awis.py` and `requirements.txt`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
