### PR TITLE
updates to work with current modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+python/.awis.py.credentials
+*.venv
+python/.tool-versions
+python/Makefile

--- a/python/awis.py
+++ b/python/awis.py
@@ -19,7 +19,7 @@ import sys, os, base64, hashlib, hmac
 import logging, getopt
 import boto3
 import getpass
-from botocore.vendored import requests
+import requests
 from datetime import datetime
 import time
 from configparser import ConfigParser # pip install configparser
@@ -35,7 +35,7 @@ method = 'GET'
 service = 'execute-api'
 log = logging.getLogger( "awis" )
 content_type = 'application/xml'
-local_tz = "America/Los_Angeles"
+local_tz = "America/Chicago"
 
 # ******** LOCAL CREDENTIALS FILE **********
 credentials_file = '.awis.py.credentials'

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 boto3
 configparser
 future
+requests


### PR DESCRIPTION
Stop using the botocore vendored requests module.

*Issue #, if available:*
The sample Python script uses the vendored requests module in boto, which is deprecated. Makes for a bit of trouble when just trying to run the example script under Python 3.

*Description of changes:*
- Added requests module to requirements.txt
- Use requests module in awis.py
- Added a .gitignore line for python/.awis.py.credentials because that really needs to not end up in version control. The other lines in .gitignore you can take or leave, since they are just for my env set-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
